### PR TITLE
Dev clock applet

### DIFF
--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/apps/mate-applications.css
@@ -192,6 +192,7 @@ PanelApplet.wnck-applet .wnck-pager {
 /* set normal menubar menuitem */
 .mate-panel-menu-bar menubar > menuitem {
     background-image: none;
+    box-shadow: none;
 }
 
 /* set selected menubar menuitem */
@@ -277,9 +278,33 @@ na-tray-applet {
     -NaTrayApplet-icon-padding: 1px; /*any more and outlines get cut off*/
 }
 
-/* Classic icon style */
-.mate-panel-menu-bar {
-    -PanelMenuBar-icon-visible: true;
+/* clock-applet */
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:hover {
+    background-color: @dark_bg_color;
+    background-image: none;
+    border-width: 0;
+    color: @dark_fg_color;
+    text-shadow: 0 -1px shade (@dark_bg_color, 0.6);
+    padding: 3px 5px 3px 5px;
+    border: 1px solid transparent;
+}
+
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked:hover {
+    background-color: transparent;
+    background-clip: border-box;
+    background-image: -gtk-gradient (linear, left top, left bottom,
+                                     from (shade (@dark_bg_color, 1.38)),
+                                     to (shade (@dark_bg_color, 1.11)));
+    box-shadow: none;
+    color: shade (@dark_fg_color, 1.1);
+    text-shadow: 0 -1px shade (@dark_bg_color, 0.7);
+}
+
+/* clock window */
+#MatePanelPopupWindow {
+	border-radius: 3px;
 }
 
 /* volume applet */
@@ -320,15 +345,15 @@ na-tray-applet {
     margin: 0px;
 }
 
-/* clock window */
-#MatePanelPopupWindow {
-	border-radius: 3px;
-}
-
 /* mate-indicator-applet */
 /* needed for a transparent panel */
 #fast-user-switch-applet > #fast-user-switch-menubar {
     background-color: transparent;
+}
+
+/* Classic icon style */
+.mate-panel-menu-bar {
+    -PanelMenuBar-icon-visible: true;
 }
 
 /*****************

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
@@ -186,6 +186,7 @@ PanelApplet.wnck-applet .wnck-pager {
 /* set normal menubar menuitem */
 .mate-panel-menu-bar menubar > menuitem {
     background-image: none;
+    box-shadow: none;
 }
 
 /* set selected menubar menuitem */
@@ -271,9 +272,33 @@ na-tray-applet {
     -NaTrayApplet-icon-padding: 1px; /*any more and outlines get cut off*/
 }
 
-/* Classic icon style */
-.mate-panel-menu-bar {
-    -PanelMenuBar-icon-visible: true;
+/* clock-applet */
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:hover {
+    background-color: @dark_bg_color;
+    background-image: none;
+    border-width: 0;
+    color: @dark_fg_color;
+    text-shadow: 0 -1px shade (@dark_bg_color, 0.6);
+    padding: 3px 5px 3px 5px;
+    border: 1px solid transparent;
+}
+
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked:hover {
+    background-color: transparent;
+    background-clip: border-box;
+    background-image: -gtk-gradient (linear, left top, left bottom,
+                                     from (shade (@dark_bg_color, 1.38)),
+                                     to (shade (@dark_bg_color, 1.11)));
+    box-shadow: none;
+    color: shade (@dark_fg_color, 1.1);
+    text-shadow: 0 -1px shade (@dark_bg_color, 0.7);
+}
+
+/* clock window */
+#MatePanelPopupWindow {
+	border-radius: 3px;
 }
 
 /* volume applet */
@@ -314,15 +339,15 @@ na-tray-applet {
     margin: 0px;
 }
 
-/* clock window */
-#MatePanelPopupWindow {
-	border-radius: 3px;
-}
-
 /* mate-indicator-applet */
 /* needed for a transparent panel */
 #fast-user-switch-applet > #fast-user-switch-menubar {
     background-color: transparent;
+}
+
+/* Classic icon style */
+.mate-panel-menu-bar {
+    -PanelMenuBar-icon-visible: true;
 }
 
 /*****************

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/apps/mate-applications.css
@@ -150,6 +150,37 @@ na-tray-applet {
     -NaTrayApplet-icon-padding: 1px; /*any more and outlines get cut off*/
 }
 
+/* clock-applet */
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:hover {
+    background-color: transparent;
+    background-image: none;
+    color: @dark_fg_color;
+    text-shadow: none;
+    padding: 3px 5px 3px 5px;
+    border: 1px solid transparent;
+    border-bottom-width: 0px;
+    border-radius: 4px 4px 0 0;
+}
+
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked,
+.mate-panel-menu-bar #PanelApplet #clock-applet-button.flat.toggle:checked:hover {
+    background-color: transparent;
+    background-clip: border-box;
+    background-image: -gtk-gradient (linear, left top, left bottom,
+                                     from (shade (@dark_bg_color, 1.38)),
+                                     to (shade (@dark_bg_color, 1.11)));
+    box-shadow: inset 0 1px 1px 0 shade (@dark_bg_color, 1.8);
+    color: shade (@dark_fg_color, 1.1);
+    text-shadow: 0 1px shade (@dark_bg_color, 1.1);
+    border-color: #b8ab9c;
+}
+
+/* clock window */
+#MatePanelPopupWindow {
+	border-radius: 3px;
+}
+
 /* volume applet */
 .mate-panel-applet-slider,
 .mate-panel-applet-slider.background {


### PR DESCRIPTION
Please test.
We use only 2 button states now, normal and checked.
**hover** state use the same styling as **normal** and **checked:hover** use same as **checked**.
This is complete similar to normal menubar.
I you agree i will do the same for other themes.
Fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/2