### PR TITLE
Ambiant-MATE: drop light border from multiload-applet

### DIFF
--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/apps/mate-applications.css
@@ -360,6 +360,18 @@ na-tray-applet {
     -PanelMenuBar-icon-visible: true;
 }
 
+/* system-monitor-applet, kill frame border */
+.multiload-applet > box.horizontal > box.vertical > frame > border {
+    border-color: transparent;
+}
+
+.multiload-applet > box.horizontal > box.vertical > frame {
+    box-shadow: inset  0px  1px shade (@dark_bg_color, 1.2),
+                inset  1px  0px shade (@dark_bg_color, 1.2),
+                inset -1px  0px shade (@dark_bg_color, 1.2),
+                inset  0px -1px shade (@dark_bg_color, 1.2);
+}
+
 /*****************
  * Mate-terminal *
  *****************/

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
@@ -357,6 +357,13 @@ na-tray-applet {
     border-color: transparent;
 }
 
+.multiload-applet > box.horizontal > box.vertical > frame {
+    box-shadow: inset  0px  1px shade (@dark_bg_color, 1.2),
+                inset  1px  0px shade (@dark_bg_color, 1.2),
+                inset -1px  0px shade (@dark_bg_color, 1.2),
+                inset  0px -1px shade (@dark_bg_color, 1.2);
+}
+
 /*****************
  * Mate-terminal *
  *****************/

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/apps/mate-applications.css
@@ -352,6 +352,11 @@ na-tray-applet {
     -PanelMenuBar-icon-visible: true;
 }
 
+/* system-monitor-applet, kill light frame border */
+.multiload-applet > box.horizontal > box.vertical > frame > border {
+    border-color: transparent;
+}
+
 /*****************
  * Mate-terminal *
  *****************/

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/apps/mate-applications.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/apps/mate-applications.css
@@ -249,6 +249,18 @@ na-tray-applet {
     background-color: transparent;
 }
 
+/* system-monitor-applet, kill frame border */
+.multiload-applet > box.horizontal > box.vertical > frame > border {
+    border-color: transparent;
+}
+
+.multiload-applet > box.horizontal > box.vertical > frame {
+    box-shadow: inset  0px  1px shade (@theme_bg_color, 0.9),
+                inset  1px  0px shade (@theme_bg_color, 0.9),
+                inset -1px  0px shade (@theme_bg_color, 0.9),
+                inset  0px -1px shade (@theme_bg_color, 0.9);
+}
+
 /*****************
  * Mate-terminal *
  *****************/


### PR DESCRIPTION
You need to add this commit to mate-applets to get this working.
https://github.com/mate-desktop/mate-applets/commit/147ca93e4d36337b311ee592a1a142dde8e5ded0

Fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/3

Please test.