### PR TITLE
gtk-widgets: add suggested-action button style

### DIFF
--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -289,6 +289,16 @@ button.destructive-action {
     text-shadow: 0 1px shade(#9d4242, 1.15);
 }
 
+button.suggested-action {
+    background-image: linear-gradient(to bottom, #6699CC, #5C83AA);
+    border-color: #055200;
+    border-image: none;
+    color: white;
+    -gtk-icon-shadow: 0 1px shade(#9d4242, 1.15);
+    outline-color: rgba(255, 255, 255, 0.3);
+    text-shadow: 0 1px shade(#4F9D42, 1.15);
+}
+
 /* eg. mate-appearance-properties */
 button.link.flat.text-button:focus {
     outline-style: dashed;

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -293,6 +293,16 @@ button.destructive-action {
     text-shadow: 0 1px shade(#9d4242, 1.15);
 }
 
+button.suggested-action {
+    background-image: linear-gradient(to bottom, #6699CC, #5C83AA);
+    border-color: #055200;
+    border-image: none;
+    color: white;
+    -gtk-icon-shadow: 0 1px shade(#9d4242, 1.15);
+    outline-color: rgba(255, 255, 255, 0.3);
+    text-shadow: 0 1px shade(#4F9D42, 1.15);
+}
+
 /* eg. mate-appearance-properties */
 button.link.flat.text-button:focus {
     outline-style: dashed;

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -293,6 +293,16 @@ button.destructive-action {
     text-shadow: 0 1px shade(#9d4242, 1.15);
 }
 
+button.suggested-action {
+    background-image: linear-gradient(to bottom, #6699CC, #5C83AA);
+    border-color: #055200;
+    border-image: none;
+    color: white;
+    -gtk-icon-shadow: 0 1px shade(#9d4242, 1.15);
+    outline-color: rgba(255, 255, 255, 0.3);
+    text-shadow: 0 1px shade(#4F9D42, 1.15);
+}
+
 /* eg. mate-appearance-properties */
 button.link.flat.text-button:focus {
     outline-style: dashed;


### PR DESCRIPTION
Hi,
this adds a button.suggested-action to the gtk-widget.css files in order to get nice buttons in mate-calc (mate-desktop/mate-calc#105). I chose a blue colour, but feel free to edit this to your liking.

![Screenshot at 2019-05-09 23-59-41](https://user-images.githubusercontent.com/39454100/57489520-8c00fc80-72b6-11e9-80f7-6155f887750d.png)
