### PR TITLE
add missing cross icons from humanity theme

### DIFF
--- a/usr/share/icons/Ambiant-MATE/actions/16/button_cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/dialog-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/dialog-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/dialog-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/gtk-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/gtk-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/stock_calc-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/stock_close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/stock_no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/16/window-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/16/window-close.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3245" width="16" height="16" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs3247">
+  <linearGradient id="linearGradient3234" x1="11.192" x2="11.192" y1="3" y2="22" gradientTransform="matrix(.57895 0 0 .61111 1.0526 .36108)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3231" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.30773 -.32448 .30773 .32448 -7.0772 7.6731)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3228" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.30773 -.32448 .30773 .32448 -7.3874 7.8369)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1">
+  <path id="text1314" d="m13.5 11.239-3.185-3.2408 3.0647-3.3951-2.2092-2.1029-3.154 3.2353-3.218-3.2353-2.2985 2.1803 3.218 3.3039-3.218 3.2511 2.2985 2.2647 3.2142-3.3971 3.2217 3.3971 2.2656-2.2612z" style="fill:url(#linearGradient3234);stroke:#4d4d4d"/>
+  <path id="path7076" d="m12.003 4.6567-0.77162-0.74977-3.1492 3.2625-3.3058-3.2433-0.86319 0.79641" style="fill:none;opacity:.3;stroke-linecap:square;stroke:url(#linearGradient3231)"/>
+  <path id="path3165" d="m12.449 11.612-3.1045-3.2132m-2.6538-0.00618-3.1094 3.1907" style="fill:none;opacity:.3;stroke:url(#linearGradient3228)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Ambiant-MATE/actions/22/button_cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/dialog-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/dialog-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/dialog-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/gtk-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/gtk-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/stock_calc-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/stock_close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/stock_no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/22/window-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/22/window-close.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" width="22" height="22" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs4">
+  <radialGradient id="radialGradient2410" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" style="stop-opacity:.39216" offset="0"/>
+   <stop id="stop3169" style="stop-opacity:.31373" offset=".5"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient3217" x1="11.192" x2="11.192" y1="3" y2="22" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3167" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.042 11.965)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2419" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.578 12.233)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1" transform="translate(-1 -1)">
+  <path id="path1361" transform="matrix(1.1629 0 0 .96975 -14.698 -12.134)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2410);opacity:.4"/>
+  <path id="text1314" d="m21.5 17.8-5.5013-5.3031 5.2936-5.5555-3.8159-3.4412-5.4478 5.2941-5.5583-5.2941-3.9702 3.5677 5.5583 5.4063-5.5583 5.32 3.9702 3.7059 5.5518-5.5588 5.5647 5.5588 3.9133-3.7002z" style="fill:url(#linearGradient3217);stroke-linejoin:round;stroke:#4d4d4d"/>
+  <path id="path7076" d="m19.904 6.9841-2.4091-2.1004-5.4953 5.3089-5.5-5.3786-2.5 2.2591" style="fill:none;opacity:.4;stroke-linecap:square;stroke:url(#linearGradient3167)"/>
+  <path id="path3165" d="m20.398 18.05-5.4574-5.2579m-5.9157 0.2152-5.5611 5.3112" style="fill:none;opacity:.4;stroke:url(#linearGradient2419)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Ambiant-MATE/actions/24/button_cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/dialog-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/dialog-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/dialog-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/gtk-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/gtk-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/stock_calc-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/stock_close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/stock_no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/24/window-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/24/window-close.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" width="24" height="24" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs4">
+  <radialGradient id="radialGradient2410" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" style="stop-opacity:.39216" offset="0"/>
+   <stop id="stop3169" style="stop-opacity:.31373" offset=".5"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient3217" x1="11.192" x2="11.192" y1="3" y2="22" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3167" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.042 11.965)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2419" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.578 12.233)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1">
+  <path id="path1361" transform="matrix(1.1629 0 0 .96975 -14.698 -12.134)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2410);opacity:.4"/>
+  <path id="text1314" d="m21.5 17.8-5.5013-5.3031 5.2936-5.5555-3.8159-3.4412-5.4478 5.2941-5.5583-5.2941-3.9702 3.5677 5.5583 5.4063-5.5583 5.32 3.9702 3.7059 5.5518-5.5588 5.5647 5.5588 3.9133-3.7002z" style="fill:url(#linearGradient3217);stroke-linejoin:round;stroke:#4d4d4d"/>
+  <path id="path7076" d="m19.904 6.9841-2.4091-2.1004-5.4953 5.3089-5.5-5.3786-2.5 2.2591" style="fill:none;opacity:.4;stroke-linecap:square;stroke:url(#linearGradient3167)"/>
+  <path id="path3165" d="m20.398 18.05-5.4574-5.2579m-5.9157 0.2152-5.5611 5.3112" style="fill:none;opacity:.4;stroke:url(#linearGradient2419)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Ambiant-MATE/actions/48/button_cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/dialog-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/dialog-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/dialog-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/gtk-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/gtk-no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/stock_calc-cancel.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/stock_close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/stock_no.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Ambiant-MATE/actions/48/window-close.svg
+++ b/usr/share/icons/Ambiant-MATE/actions/48/window-close.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2405" width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs2407">
+  <radialGradient id="radialGradient2177" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" offset="0"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient2181" x1="31.865" x2="16.145" y1="17.13" y2="32.85" gradientTransform="matrix(1.0318 -1.0287 1.0318 1.0287 -26.553 23.964)" gradientUnits="userSpaceOnUse">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:.34021" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2179" x1="49.882" x2="34.163" y1="30.701" y2="46.421" gradientTransform="matrix(1.0318 -1.0287 1.0318 1.0287 -59.146 28.538)" gradientUnits="userSpaceOnUse">
+   <stop id="stop1324" style="stop-color:#b4b4b4" offset="0"/>
+   <stop id="stop1326" style="stop-color:#505050" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g id="layer1">
+  <path id="path1361" transform="matrix(2.3012 0 0 1.919 -28.833 -24.805)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2177);opacity:.25571"/>
+  <path id="text1314" d="m41.892 35.011-10.392-10.017 10-10.494-7.2086-6.5-10.291 10-10.5-10-7.5 6.7391 10.5 10.212-10.5 10.049 7.5 7 10.488-10.5 10.512 10.5 7.3925-6.9892z" style="fill:#555753;stroke-linejoin:round;stroke-width:.9817;stroke:#4d4d4d"/>
+  <path id="path7076" d="M 40.5,35 30,25 40,14.5 34.29224,9.5414417 24,19.5 13.5,9.5 7.5,15 18,24.944661 7.5,35 13.5,40.5 24,30 34.5,40.5 40.5,35 z" style="fill:url(#linearGradient2179);opacity:.4086;stroke-linejoin:round;stroke-width:.9817;stroke:url(#linearGradient2181)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Radiant-MATE/actions/16/button_cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/dialog-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/dialog-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/dialog-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/gtk-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/gtk-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/stock_calc-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/stock_close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/stock_no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/16/window-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/16/window-close.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg3245" width="16" height="16" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs3247">
+  <linearGradient id="linearGradient3234" x1="11.192" x2="11.192" y1="3" y2="22" gradientTransform="matrix(.57895 0 0 .61111 1.0526 .36108)" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3231" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.30773 -.32448 .30773 .32448 -7.0772 7.6731)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3228" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.30773 -.32448 .30773 .32448 -7.3874 7.8369)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1">
+  <path id="text1314" d="m13.5 11.239-3.185-3.2408 3.0647-3.3951-2.2092-2.1029-3.154 3.2353-3.218-3.2353-2.2985 2.1803 3.218 3.3039-3.218 3.2511 2.2985 2.2647 3.2142-3.3971 3.2217 3.3971 2.2656-2.2612z" style="fill:url(#linearGradient3234);stroke:#4d4d4d"/>
+  <path id="path7076" d="m12.003 4.6567-0.77162-0.74977-3.1492 3.2625-3.3058-3.2433-0.86319 0.79641" style="fill:none;opacity:.3;stroke-linecap:square;stroke:url(#linearGradient3231)"/>
+  <path id="path3165" d="m12.449 11.612-3.1045-3.2132m-2.6538-0.00618-3.1094 3.1907" style="fill:none;opacity:.3;stroke:url(#linearGradient3228)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Radiant-MATE/actions/22/button_cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/dialog-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/dialog-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/dialog-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/gtk-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/gtk-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/stock_calc-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/stock_close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/stock_no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/22/window-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/22/window-close.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" width="22" height="22" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs4">
+  <radialGradient id="radialGradient2410" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" style="stop-opacity:.39216" offset="0"/>
+   <stop id="stop3169" style="stop-opacity:.31373" offset=".5"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient3217" x1="11.192" x2="11.192" y1="3" y2="22" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3167" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.042 11.965)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2419" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.578 12.233)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1" transform="translate(-1 -1)">
+  <path id="path1361" transform="matrix(1.1629 0 0 .96975 -14.698 -12.134)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2410);opacity:.4"/>
+  <path id="text1314" d="m21.5 17.8-5.5013-5.3031 5.2936-5.5555-3.8159-3.4412-5.4478 5.2941-5.5583-5.2941-3.9702 3.5677 5.5583 5.4063-5.5583 5.32 3.9702 3.7059 5.5518-5.5588 5.5647 5.5588 3.9133-3.7002z" style="fill:url(#linearGradient3217);stroke-linejoin:round;stroke:#4d4d4d"/>
+  <path id="path7076" d="m19.904 6.9841-2.4091-2.1004-5.4953 5.3089-5.5-5.3786-2.5 2.2591" style="fill:none;opacity:.4;stroke-linecap:square;stroke:url(#linearGradient3167)"/>
+  <path id="path3165" d="m20.398 18.05-5.4574-5.2579m-5.9157 0.2152-5.5611 5.3112" style="fill:none;opacity:.4;stroke:url(#linearGradient2419)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Radiant-MATE/actions/24/button_cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/dialog-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/dialog-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/dialog-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/gtk-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/gtk-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/stock_calc-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/stock_close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/stock_no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/24/window-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/24/window-close.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2" width="24" height="24" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs4">
+  <radialGradient id="radialGradient2410" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" style="stop-opacity:.39216" offset="0"/>
+   <stop id="stop3169" style="stop-opacity:.31373" offset=".5"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient3217" x1="11.192" x2="11.192" y1="3" y2="22" gradientUnits="userSpaceOnUse">
+   <stop id="stop3205" style="stop-color:#777976" offset="0"/>
+   <stop id="stop3207" style="stop-color:#565755" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient3167" x1="36.011" x2="16.331" y1="13.023" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.042 11.965)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+  <linearGradient id="linearGradient7916">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2419" x1="28.449" x2="16.331" y1="20.584" y2="32.702" gradientTransform="matrix(.53153 -.53096 .53153 .53096 -14.578 12.233)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient7916"/>
+ </defs>
+ <g id="layer1">
+  <path id="path1361" transform="matrix(1.1629 0 0 .96975 -14.698 -12.134)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2410);opacity:.4"/>
+  <path id="text1314" d="m21.5 17.8-5.5013-5.3031 5.2936-5.5555-3.8159-3.4412-5.4478 5.2941-5.5583-5.2941-3.9702 3.5677 5.5583 5.4063-5.5583 5.32 3.9702 3.7059 5.5518-5.5588 5.5647 5.5588 3.9133-3.7002z" style="fill:url(#linearGradient3217);stroke-linejoin:round;stroke:#4d4d4d"/>
+  <path id="path7076" d="m19.904 6.9841-2.4091-2.1004-5.4953 5.3089-5.5-5.3786-2.5 2.2591" style="fill:none;opacity:.4;stroke-linecap:square;stroke:url(#linearGradient3167)"/>
+  <path id="path3165" d="m20.398 18.05-5.4574-5.2579m-5.9157 0.2152-5.5611 5.3112" style="fill:none;opacity:.4;stroke:url(#linearGradient2419)"/>
+ </g>
+</svg>

--- a/usr/share/icons/Radiant-MATE/actions/48/button_cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/button_cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/dialog-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/dialog-cancel.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/dialog-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/dialog-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/dialog-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/dialog-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/gtk-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/gtk-close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/gtk-no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/gtk-no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/stock_calc-cancel.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/stock_calc-cancel.svg
@@ -1,0 +1,1 @@
+dialog-cancel.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/stock_close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/stock_close.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/stock_no.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/stock_no.svg
@@ -1,0 +1,1 @@
+window-close.svg

--- a/usr/share/icons/Radiant-MATE/actions/48/window-close.svg
+++ b/usr/share/icons/Radiant-MATE/actions/48/window-close.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg2405" width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs id="defs2407">
+  <radialGradient id="radialGradient2177" cx="23.071" cy="35.127" r="10.319" gradientTransform="matrix(.91481 .01265 -.008215 .21356 2.2539 27.189)" gradientUnits="userSpaceOnUse">
+   <stop id="stop2093" offset="0"/>
+   <stop id="stop2095" style="stop-opacity:0" offset="1"/>
+  </radialGradient>
+  <linearGradient id="linearGradient2181" x1="31.865" x2="16.145" y1="17.13" y2="32.85" gradientTransform="matrix(1.0318 -1.0287 1.0318 1.0287 -26.553 23.964)" gradientUnits="userSpaceOnUse">
+   <stop id="stop7918" style="stop-color:#fff" offset="0"/>
+   <stop id="stop7920" style="stop-color:#fff;stop-opacity:.34021" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient2179" x1="49.882" x2="34.163" y1="30.701" y2="46.421" gradientTransform="matrix(1.0318 -1.0287 1.0318 1.0287 -59.146 28.538)" gradientUnits="userSpaceOnUse">
+   <stop id="stop1324" style="stop-color:#b4b4b4" offset="0"/>
+   <stop id="stop1326" style="stop-color:#505050" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g id="layer1">
+  <path id="path1361" transform="matrix(2.3012 0 0 1.919 -28.833 -24.805)" d="m33.278 34.941a10.319 2.3202 0 1 1-20.639 0 10.319 2.3202 0 1 1 20.639 0z" style="fill:url(#radialGradient2177);opacity:.25571"/>
+  <path id="text1314" d="m41.892 35.011-10.392-10.017 10-10.494-7.2086-6.5-10.291 10-10.5-10-7.5 6.7391 10.5 10.212-10.5 10.049 7.5 7 10.488-10.5 10.512 10.5 7.3925-6.9892z" style="fill:#555753;stroke-linejoin:round;stroke-width:.9817;stroke:#4d4d4d"/>
+  <path id="path7076" d="M 40.5,35 30,25 40,14.5 34.29224,9.5414417 24,19.5 13.5,9.5 7.5,15 18,24.944661 7.5,35 13.5,40.5 24,30 34.5,40.5 40.5,35 z" style="fill:url(#linearGradient2179);opacity:.4086;stroke-linejoin:round;stroke-width:.9817;stroke:url(#linearGradient2181)"/>
+ </g>
+</svg>


### PR DESCRIPTION
It seems that inherit icons from humanty theme
doesn't work very well and the existing symbolic version was used.
The button itself used the windows-close icon since GtkStock
deprecation fixes with MATE-1.22

fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/46

Please test.