### PR TITLE
A&AD&R: increase treeview expander size

### DIFF
--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -6,7 +6,7 @@
     -GtkTextView-error-underline-color: #df382c; /* @error_color doesn't work due to a gtk bug */
     -GtkToolButton-icon-spacing: 6;
     -GtkToolItemGroup-expander-size: 11;
-    -GtkTreeView-expander-size: 8;
+    -GtkTreeView-expander-size: 16;
     -GtkTreeView-vertical-separator: 0;
     -GtkWindow-resize-grip-width: 0;
     -GtkWindow-resize-grip-height: 0;

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -6,7 +6,7 @@
     -GtkTextView-error-underline-color: #df382c; /* @error_color doesn't work due to a gtk bug */
     -GtkToolButton-icon-spacing: 6;
     -GtkToolItemGroup-expander-size: 11;
-    -GtkTreeView-expander-size: 8;
+    -GtkTreeView-expander-size: 16;
     -GtkTreeView-vertical-separator: 0;
     -GtkWindow-resize-grip-width: 0;
     -GtkWindow-resize-grip-height: 0;

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -6,7 +6,7 @@
     -GtkTextView-error-underline-color: #df382c; /* @error_color doesn't work due to a gtk bug */
     -GtkToolButton-icon-spacing: 6;
     -GtkToolItemGroup-expander-size: 11;
-    -GtkTreeView-expander-size: 8;
+    -GtkTreeView-expander-size: 16;
     -GtkTreeView-vertical-separator: 0;
     -GtkWindow-resize-grip-width: 0;
     -GtkWindow-resize-grip-height: 0;


### PR DESCRIPTION
fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/42

I offer various expander sizes 12/14/16px in themes. Let me which size you prefer.
Than i will update commit.