### PR TITLE
A few retro (16.04) theme tweaks

### DIFF
--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -1129,7 +1129,7 @@ menu,
     border-left-color: shade (@dark_bg_color, 0.8);
     border-right-color: shade (@dark_bg_color, 0.8);
     border-top-color: shade (@dark_bg_color, 0.96);
-    padding: 0;
+    padding: 3px 0;
     border-width: 1px;
     border-style: solid;
 
@@ -1220,7 +1220,7 @@ menubar > menuitem,
 menu > menuitem {
     background: transparent;
     border-radius: 0;
-    padding: 4px 5px 4px 5px;
+    padding: 3px 5px 3px 5px;
     text-shadow: none;
 }
 

--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -3683,6 +3683,13 @@ treeview.view {
 	outline-color: alpha(currentColor, 0.6);
 }
 
+treeview header button {
+	background: linear-gradient(to bottom,
+			shade(@bg_color, 1.04),
+			shade(@bg_color, 1.02));
+	padding: 4px 4px;
+}
+
 /* ie. ubiquity */
 scrolledwindow.frame > treeview.view > check {
     background-color: transparent;

--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -3321,6 +3321,10 @@ toolbar:backdrop {
     color: @backdrop_fg_color;
 }
 
+toolbar separator {
+    margin: 0 4px;
+}
+
 /*******************
  * primary-toolbar *
  *******************/

--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -550,8 +550,8 @@ radio:disabled {
 check,
 radio {
 	padding: 0px 6px 0px 0px;
-	min-height: 12px;
-	min-width: 12px;
+	min-height: 16px;
+	min-width: 16px;
 }
 
 checkbutton:hover,

--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -1381,8 +1381,9 @@ menu separator,
 .menu separator,
 menuitem separator {
     min-height: 1px;
-    background-color: shade(@dark_bg_color, 0.9);
+    background: shade(@dark_bg_color, 0.9);
     border-style: none;
+    margin: 3px 0;
 }
 
 /* fix for broken firefox */

--- a/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE-Dark/gtk-3.0/gtk-widgets.css
@@ -1537,9 +1537,9 @@ notebook header tab {
     border-width: 1px;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
-                      @notebook_tab_gradient_a,
-                      @notebook_tab_gradient_d);
-    padding: 6px;
+                      @notebook_tab_gradient_b,
+                      @notebook_tab_gradient_a);
+    padding: 4px 8px;
 }
 
 notebook header tab label {
@@ -1671,7 +1671,7 @@ dialog.background.ssd > box.vertical.dialog-vbox > notebook > header.top tab,
 dialog.background.solid-csd > box.vertical.dialog-vbox > notebook > header.top tab,
 printdialog notebook > header.top tab,
 notebook.frame > header.top tab {
-    padding: 6px;
+    padding: 4px 8px;
     border-radius: 4px 4px 0px 0px;
 }
 
@@ -1699,7 +1699,7 @@ notebook.frame > header.top tab:checked:hover {
 }
 
 notebook.frame > header.bottom tab {
-    padding: 6px;
+    padding: 4px 8px;
 }
 
 notebook.frame > header.bottom tab:checked,

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1386,8 +1386,9 @@ menu separator,
 .menu separator,
 menuitem separator {
     min-height: 1px;
-    background-color: shade(@fg_color, 0.7);
+    background: shade(@dark_bg_color, 1);
     border-style: none;
+    margin: 3px 0;
 }
 
 /* fix for broken firefox */

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -555,8 +555,8 @@ radio:disabled {
 check,
 radio {
 	padding: 0px 6px 0px 0px;
-	min-height: 12px;
-	min-width: 12px;
+	min-height: 16px;
+	min-width: 16px;
 }
 
 checkbutton:hover,

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -3348,6 +3348,10 @@ toolbar:backdrop {
     color: @backdrop_fg_color;
 }
 
+toolbar separator {
+    margin: 0 4px;
+}
+
 /*******************
  * primary-toolbar *
  *******************/

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -3722,6 +3722,13 @@ treeview.view {
 	outline-color: alpha(currentColor, 0.6);
 }
 
+treeview header button {
+	background: linear-gradient(to bottom,
+			shade(@bg_color, 1.04),
+			shade(@bg_color, 1.02));
+	padding: 4px 4px;
+}
+
 /* ie. ubiquity */
 scrolledwindow.frame > treeview.view > check {
     background-color: transparent;

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1134,7 +1134,7 @@ menu,
     border-left-color: shade (@dark_bg_color, 0.8);
     border-right-color: shade (@dark_bg_color, 0.8);
     border-top-color: shade (@dark_bg_color, 0.96);
-    padding: 0;
+    padding: 3px 0;
     border-width: 1px;
     border-style: solid;
 
@@ -1225,7 +1225,7 @@ menubar > menuitem,
 menu > menuitem {
     background: transparent;
     border-radius: 0;
-    padding: 4px 5px 4px 5px;
+    padding: 3px 5px 3px 5px;
     text-shadow: none;
 }
 

--- a/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Ambiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1542,9 +1542,9 @@ notebook header tab {
     border-width: 1px;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
-                      @notebook_tab_gradient_a,
-                      @notebook_tab_gradient_d);
-    padding: 6px;
+                      @notebook_tab_gradient_b,
+                      @notebook_tab_gradient_a);
+    padding: 4px 8px;
 }
 
 notebook header tab label {
@@ -1675,7 +1675,7 @@ dialog.background.ssd > box.vertical.dialog-vbox > notebook > header.top tab,
 dialog.background.solid-csd > box.vertical.dialog-vbox > notebook > header.top tab,
 printdialog notebook > header.top tab,
 notebook.frame > header.top tab {
-    padding: 6px;
+    padding: 4px 8px;
     border-radius: 4px 4px 0px 0px;
 }
 
@@ -1702,7 +1702,7 @@ notebook.frame > header.top tab:checked:hover {
 }
 
 notebook.frame > header.bottom tab {
-    padding: 6px;
+    padding: 4px 8px;
 }
 
 notebook.frame > header.bottom tab:checked,

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -3337,6 +3337,10 @@ toolbar:backdrop {
     color: @backdrop_fg_color;
 }
 
+toolbar separator {
+    margin: 0 4px;
+}
+
 /*******************
  * primary-toolbar *
  *******************/

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1140,7 +1140,7 @@ menu,
     border-left-color: shade (@dark_bg_color, 0.8);
     border-right-color: shade (@dark_bg_color, 0.8);
     border-top-color: shade (@dark_bg_color, 0.96);
-    padding: 0;
+    padding: 3px 0;
     border-width: 1px;
     border-style: solid;
 
@@ -1249,7 +1249,7 @@ menubar > menuitem,
 menu > menuitem {
     background: transparent;
     border-radius: 0;
-    padding: 4px 5px 4px 5px;
+    padding: 3px 5px 3px 5px;
     text-shadow: none;
 }
 

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1562,9 +1562,9 @@ notebook header tab {
     border-width: 1px;
     background-color: transparent;
     background-image: linear-gradient(to bottom,
-                      @notebook_tab_gradient_a,
-                      @notebook_tab_gradient_d);
-    padding: 6px;
+                      @notebook_tab_gradient_b,
+                      @notebook_tab_gradient_a);
+    padding: 4px 8px;
 }
 
 notebook header tab label {
@@ -1695,7 +1695,7 @@ dialog.background.ssd > box.vertical.dialog-vbox > notebook > header.top tab,
 dialog.background.solid-csd > box.vertical.dialog-vbox > notebook > header.top tab,
 printdialog notebook > header.top tab,
 notebook.frame > header.top tab {
-    padding: 6px;
+    padding: 4px 8px;
     border-radius: 4px 4px 0px 0px;
 }
 
@@ -1722,7 +1722,7 @@ notebook.frame > header.top tab:checked:hover {
 }
 
 notebook.frame > header.bottom tab {
-    padding: 6px;
+    padding: 4px 8px;
 }
 
 notebook.frame > header.bottom tab:checked,

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -3691,6 +3691,13 @@ treeview.view {
 	outline-color: alpha(currentColor, 0.6);
 }
 
+treeview header button {
+	background: linear-gradient(to bottom,
+			shade(@bg_color, 1.04),
+			shade(@bg_color, 1.02));
+	padding: 4px 4px;
+}
+
 /* ie. ubiquity */
 scrolledwindow.frame > treeview.view > check {
     background-color: transparent;

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -1406,8 +1406,9 @@ menu separator,
 .menu separator,
 menuitem separator {
     min-height: 1px;
-    background-color: shade(@bg_color, 0.9);
+    background: shade(@bg_color, 0.9);
     border-style: none;
+    margin: 3px 0;
 }
 
 /* fix for broken firefox */

--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -560,8 +560,8 @@ radio:disabled {
 check,
 radio {
 	padding: 0px 6px 0px 0px;
-	min-height: 12px;
-	min-width: 12px;
+	min-height: 16px;
+	min-width: 16px;
 }
 
 checkbutton:hover,


### PR DESCRIPTION
Coming from the GTK2 variant of the Ambiant-MATE themes, here's some tweaks to address some personal eyesores to make it retrospectively closer to the 16.04 version of theme.

### Controls
**Before**

![controls-before](https://user-images.githubusercontent.com/13032135/57588077-df698980-7506-11e9-861f-b6432c3e9961.png) 

**After**

![controls-after](https://user-images.githubusercontent.com/13032135/57588079-e0022000-7506-11e9-8569-76881ec9feec.png) 

### Tabs
**Before** 

![tabs-before](https://user-images.githubusercontent.com/13032135/57588084-fc05c180-7506-11e9-9d20-a9aa52fde1bf.png)

_Note the gradients were quite dark for inactive tabs._

**After**

![tabs-after](https://user-images.githubusercontent.com/13032135/57588085-fd36ee80-7506-11e9-9605-307498f94385.png) 

**GTK2** (for comparison)

![tabs-gtk2](https://user-images.githubusercontent.com/13032135/57588086-fe681b80-7506-11e9-9782-9f98257cd673.png)

### Treeview

**Before**

![treeview-before](https://user-images.githubusercontent.com/13032135/57588100-5010a600-7507-11e9-99c5-73f593e88bae.png)


**After**

![treeview-after](https://user-images.githubusercontent.com/13032135/57588102-51da6980-7507-11e9-8e31-1a5fe924b0de.png)

---
Components were tested against the GTK Widget Factory. Changes include the Dark and Radiant themes. More changes possibly to come!