### PR TITLE
Radiant: use green image-buttons for hover state

### DIFF
--- a/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Radiant-MATE/gtk-3.0/gtk-widgets.css
@@ -4243,7 +4243,9 @@ modelbutton.flat:backdrop:hover {
 }
 
 modelbutton.flat:hover,
-modelbutton.flat:backdrop:hover {
+modelbutton.flat:backdrop:hover,
+.linked button.image-button.model:hover,
+.linked button.image-button.model:backdrop:hover {
     background-image: -gtk-gradient (linear, left top, left bottom,
                                      from (shade (@selected_bg_color, 1.1)),
                                      to (shade (@selected_bg_color, 0.9)));
@@ -4286,8 +4288,8 @@ modelbutton.flat *:disabled {
 .linked button.image-button.model:last-child,
 .linked button.image-button.model:focus:last-child {
     border-color: transparent;
-    box-shadow: none;
     border-radius: 6px;
+    border-image: none;
 }
 
 /* middle button*/
@@ -4297,8 +4299,21 @@ modelbutton.flat *:disabled {
 .linked button.image-button.model:hover:active,
 .linked button.image-button.model:checked:hover,
 .linked button.image-button.model:checked:hover:active {
-    border-left-width: 0px;
     border-radius: 0;
+    border-width: 1px 1px 1px 0px;
+    box-shadow: inset 0 1px shade (@theme_bg_color, 0.75),
+                inset 0 -1px shade (@theme_bg_color, 0.75),
+                inset -1px 0 shade (@theme_bg_color, 0.75);
+}
+
+.linked button.image-button.model:checked,
+.linked button.image-button.model:hover,
+.linked button.image-button.model:hover:active,
+.linked button.image-button.model:checked:hover,
+.linked button.image-button.model:checked:hover:active {
+    box-shadow: inset 0 1px shade (@selected_bg_color, 1.08),
+                inset 0 -1px shade (@selected_bg_color, 1.0),
+                inset -1px 0 shade (@selected_bg_color, 1.05);
 }
 
 /* left button*/
@@ -4309,16 +4324,22 @@ modelbutton.flat *:disabled {
 .linked button.image-button.model:checked:hover:first-child,
 .linked button.image-button.model:checked:hover:active:first-child {
     border-radius: 6px 0 0 6px;
-    box-shadow: inset -1px  0px shade (@theme_bg_color, 0.75);
+    border-width: 1px;
+    box-shadow: inset 0 1px shade (@theme_bg_color, 0.75), /*top*/
+                inset 0 -1px shade (@theme_bg_color, 0.75), /*bottom*/
+                inset -1px 0 shade (@theme_bg_color, 0.75), /*right*/
+                inset 1px 0 shade (@theme_bg_color, 0.75); /* left */
 }
 
-.linked button.image-button.model:focus:first-child,
 .linked button.image-button.model:checked:first-child,
 .linked button.image-button.model:hover:first-child,
 .linked button.image-button.model:hover:active:first-child,
 .linked button.image-button.model:checked:hover:first-child,
 .linked button.image-button.model:checked:hover:active:first-child {
-    box-shadow: inset -1px 0 shade (@selected_bg_color, 1.02);
+    box-shadow: inset 0 1px shade (@selected_bg_color, 1.08),
+                inset 0 -1px shade (@selected_bg_color, 1.0),
+                inset -1px 0 shade (@selected_bg_color, 1.05),
+                inset 1px 0 shade (@selected_bg_color, 1.05);
 }
 
 /* right button*/
@@ -4328,8 +4349,21 @@ modelbutton.flat *:disabled {
 .linked button.image-button.model:hover:active:last-child,
 .linked button.image-button.model:checked:hover:last-child,
 .linked button.image-button.model:checked:hover:active:last-child {
-    border-left-width:  0px;
     border-radius: 0 6px 6px 0;
+    border-width: 1px 1px 1px 0px;
+    box-shadow: inset 0 1px shade (@theme_bg_color, 0.75),
+                inset 0 -1px shade (@theme_bg_color, 0.75),
+                inset -1px 0 shade (@theme_bg_color, 0.75);
+}
+
+.linked button.image-button.model:checked:last-child,
+.linked button.image-button.model:hover:last-child,
+.linked button.image-button.model:hover:active:last-child,
+.linked button.image-button.model:checked:hover:last-child,
+.linked button.image-button.model:checked:hover:active:last-child {
+    box-shadow: inset 0 1px shade (@selected_bg_color, 1.08),
+                inset 0 -1px shade (@selected_bg_color, 1.0),
+                inset -1px 0 shade (@selected_bg_color, 1.05);
 }
 
 /* Floating bars */


### PR DESCRIPTION
fixes https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/56

I added green buttons for hover state and dropped usage of border-images.
Please test.