### PR TITLE
Fixing malformed SVG 22x22 icons for nm-applet VPN

### DIFF
--- a/usr/share/icons/Ambiant-MATE/status/22/nm-device-wired-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-device-wired-secure.svg
@@ -1,31 +1,106 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3200" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata8">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3202"/>
-  <path d="m 20,16 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,9 7,4 2,9 l 3,0 0,7 4,0 0,-7 3,0 z" id="path4348-1-9" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 20,15 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,8 7,3 2,8 l 3,0 0,7 4,0 0,-7 3,0 z" id="path4348-1" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3200"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-device-wired-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3200" />
+  <metadata
+     id="metadata8">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3202" />
+  <path
+     d="m 20,16 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,9 7,4 2,9 l 3,0 0,7 4,0 0,-7 3,0 z"
+     id="path4348-1-9"
+     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 20,15 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,8 7,3 2,8 l 3,0 0,7 4,0 0,-7 3,0 z"
+     id="path4348-1"
+     style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Ambiant-MATE/status/22/nm-signal-00-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-signal-00-secure.svg
@@ -1,45 +1,150 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3939" style="opacity:0.5" transform="translate(-0.99999998,-1)">
-    <path d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3962" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 11.145105,18 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,19.938886 11.786534,20 12.000001,20 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 11.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,18.938886 11.786534,19 12.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-00-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview23"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3939"
+     style="opacity:0.5"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3962"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 11.145105,18 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,19.938886 11.786534,20 12.000001,20 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+       id="path3196-5-7"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 11.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,18.938886 11.786534,19 12.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+       id="path3196-5"
+       style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Ambiant-MATE/status/22/nm-signal-100-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-signal-100-secure.svg
@@ -1,37 +1,130 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <path d="m 1.85,10.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 1.85,9.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 17.185515,5.8499998 20.15,9.15 20.15,9.15" id="path3683" style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-100-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <path
+     d="m 1.85,10.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+     id="path3683-5"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 1.85,9.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 17.185515,5.8499998 20.15,9.15 20.15,9.15"
+     id="path3683"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+     id="path3681-0"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+     id="path3681"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Ambiant-MATE/status/22/nm-signal-25-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-signal-25-secure.svg
@@ -1,43 +1,145 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3939" style="opacity:0.5" transform="translate(-0.99999998,-1)">
-    <path d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-25-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview22"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3939"
+     style="opacity:0.5"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Ambiant-MATE/status/22/nm-signal-50-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-signal-50-secure.svg
@@ -1,41 +1,140 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-50-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview21"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Ambiant-MATE/status/22/nm-signal-75-secure.svg
+++ b/usr/share/icons/Ambiant-MATE/status/22/nm-signal-75-secure.svg
@@ -1,39 +1,135 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-75-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#dfdbd2;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+     id="path3681-0"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+     id="path3681"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#dfdbd2;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#dfdbd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-dark/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#dfdbd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-device-wired-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-device-wired-secure.svg
@@ -1,31 +1,106 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3200" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata8">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3202"/>
-  <path d="m 20,16 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,9 7,4 2,9 l 3,0 0,7 4,0 0,-7 3,0 z" id="path4348-1-9" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 20,15 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,8 7,3 2,8 l 3,0 0,7 4,0 0,-7 3,0 z" id="path4348-1" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3200"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-device-wired-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3200" />
+  <metadata
+     id="metadata8">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3202" />
+  <path
+     d="m 20,16 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,9 7,4 2,9 l 3,0 0,7 4,0 0,-7 3,0 z"
+     id="path4348-1-9"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 20,15 -5,5 -5,-5 3,0 0,-7 4,0 0,7 3,0 z M 12,8 7,3 2,8 l 3,0 0,7 4,0 0,-7 3,0 z"
+     id="path4348-1"
+     style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-signal-00-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-signal-00-secure.svg
@@ -1,45 +1,150 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3939" style="opacity:0.5" transform="translate(-0.99999998,-1)">
-    <path d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3962" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 11.145105,18 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,19.938886 11.786534,20 12.000001,20 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 11.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,18.938886 11.786534,19 12.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-00-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview23"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3939"
+     style="opacity:0.5"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3962"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 11.145105,18 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,19.938886 11.786534,20 12.000001,20 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+       id="path3196-5-7"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 11.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 11.591259,18.938886 11.786534,19 12.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+       id="path3196-5"
+       style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-signal-100-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-signal-100-secure.svg
@@ -1,37 +1,130 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <path d="m 1.85,10.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 1.85,9.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 17.185515,5.8499998 20.15,9.15 20.15,9.15" id="path3683" style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-100-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <path
+     d="m 1.85,10.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+     id="path3683-5"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 1.85,9.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 17.185515,5.8499998 20.15,9.15 20.15,9.15"
+     id="path3683"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+     id="path3681-0"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+     id="path3681"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-signal-25-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-signal-25-secure.svg
@@ -1,43 +1,145 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3939" style="opacity:0.5" transform="translate(-0.99999998,-1)">
-    <path d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-25-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview22"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3939"
+     style="opacity:0.5"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 8.3499999,16.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 8.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+       id="path3209"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-signal-50-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-signal-50-secure.svg
@@ -1,41 +1,140 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <g id="g3916" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-50-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview21"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     id="g3916"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 5.3499998,13.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+       id="path3681-0"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 5.3499998,12.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+       id="path3681"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>

--- a/usr/share/icons/Radiant-MATE/status/22/nm-signal-75-secure.svg
+++ b/usr/share/icons/Radiant-MATE/status/22/nm-signal-75-secure.svg
@@ -1,39 +1,135 @@
-<?xml version="1.0" ?><!-- Created with Inkscape (http://www.inkscape.org/) --><svg height="22" id="svg3229" version="1.0" width="22" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg">
-  <metadata id="metadata9">
-    <rdf:RDF>
-      <cc:Work rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id="defs3231"/>
-  <g id="g3893" style="opacity:0.4" transform="translate(-0.99999998,-1)">
-    <path d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3" id="path3683-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15" id="path3683" style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  </g>
-  <path d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525" id="path3681-0" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526" id="path3681" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209-5" style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208" id="path3209" style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5-7" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z" id="path3196-5" style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
-<g id="svg3215">
-  <metadata id="metadata12">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="22"
+   id="svg3229"
+   version="1.0"
+   width="22"
+   sodipodi:docname="nm-signal-75-secure.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="10.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3229" />
+  <metadata
+     id="metadata9">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" id="base" inkscape:current-layer="svg3215" inkscape:cx="-2.6506024" inkscape:cy="13.012048" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="753" inkscape:window-maximized="1" inkscape:window-width="1280" inkscape:window-x="0" inkscape:window-y="24" inkscape:zoom="10.375" objecttolerance="10.0" pagecolor="#ffffff" showgrid="false"/>
-  <defs id="defs3217"/>
-  <path d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z" id="path2441" style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-  <path d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z" id="rect2822" style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-</g>
+  <defs
+     id="defs3231" />
+  <g
+     id="g3893"
+     style="opacity:0.4"
+     transform="translate(-0.99999998,-1)">
+    <path
+       d="m 2.85,11.144409 c 0,0 2.8977535,-3.294409 9.131958,-3.294409 6.203557,0 9.168042,3.3 9.168042,3.3"
+       id="path3683-5"
+       style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 2.85,10.144409 c 0,0 2.8977535,-3.2944092 9.131958,-3.2944092 C 18.185515,6.8499998 21.15,10.15 21.15,10.15"
+       id="path3683"
+       style="fill:none;stroke:#3c3c3c;stroke-width:1.70000005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 4.3499998,12.752608 c 0,0 2.1468917,-2.21577 6.6500012,-2.136936 4.54046,0.07949 6.649999,2.172525 6.649999,2.172525"
+     id="path3681-0"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 4.3499998,11.752608 c 0,0 2.1468917,-2.215771 6.6500012,-2.136937 4.54046,0.07949 6.649999,2.172526 6.649999,2.172526"
+     id="path3681"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,15.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209-5"
+     style="opacity:0.3;fill:none;stroke:#ffffff;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 7.3499999,14.191046 c 0,0 0.9668981,-1.071983 3.5986811,-1.092208 2.598976,-0.01997 3.701319,1.092208 3.701319,1.092208"
+     id="path3209"
+     style="fill:none;stroke:#3c3c3c;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,17 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,18.938886 10.786534,19 11.000001,19 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5-7"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 10.145105,16 c -0.471902,0 -0.854895,0.298667 -0.854895,0.666667 0,0.136758 0.0529,0.263941 0.143587,0.369778 0,0 1.007602,0.801438 1.007602,0.801438 C 10.591259,17.938886 10.786534,18 11.000001,18 c 0.253303,0 0.480993,-0.08605 0.63758,-0.222693 0,0 0.900909,-0.710397 0.900909,-0.710397 0.107541,-0.111488 0.1713,-0.250094 0.1713,-0.400243 0,-0.368 -0.382993,-0.666667 -0.854895,-0.666667 0,0 -1.70979,0 -1.70979,0 z"
+     id="path3196-5"
+     style="fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <!-- imported from 'ubuntu-mono-light/status/22/nm-vpn-lock.svg' -->
+  <g
+     id="svg3215">
+    <metadata
+       id="metadata12">
+      <rdf:RDF>
+        <cc:Work
+           rdf:about="">
+          <dc:format>image/svg+xml</dc:format>
+          <dc:type
+             rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          <dc:title />
+        </cc:Work>
+      </rdf:RDF>
+    </metadata>
+    <sodipodi:namedview
+       bordercolor="#666666"
+       borderopacity="1.0"
+       gridtolerance="10.0"
+       guidetolerance="10.0"
+       id="base"
+       inkscape:current-layer="svg3215"
+       inkscape:cx="-2.6506024"
+       inkscape:cy="13.012048"
+       inkscape:pageopacity="0.0"
+       inkscape:pageshadow="2"
+       inkscape:window-height="753"
+       inkscape:window-maximized="1"
+       inkscape:window-width="1280"
+       inkscape:window-x="0"
+       inkscape:window-y="24"
+       inkscape:zoom="10.375"
+       objecttolerance="10.0"
+       pagecolor="#ffffff"
+       showgrid="false" />
+    <defs
+       id="defs3217" />
+    <path
+       d="M 19,14 C 17.892,14 17,14.910763 17,16.03125 L 17,17 C 16.446,17 16,17.446 16,18 L 16,21 C 16,21.554 16.446,22 17,22 L 21,22 C 21.554,22 22,21.554 22,21 L 22,18 C 22,17.446 21.554,17 21,17 L 21,16.03125 C 21,14.910764 20.108,14 19,14 z M 19,15 C 19.554,15 20,15.442363 20,16 L 20,17 L 18,17 L 18,16 C 18,15.442363 18.446,15 19,15 z"
+       id="path2441"
+       style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 19,13 C 17.892,13 17,13.910763 17,15.03125 L 17,16 C 16.446,16 16,16.446 16,17 L 16,20 C 16,20.554 16.446,21 17,21 L 21,21 C 21.554,21 22,20.554 22,20 L 22,17 C 22,16.446 21.554,16 21,16 L 21,15.03125 C 21,13.910764 20.108,13 19,13 z M 19,14 C 19.554,14 20,14.442363 20,15 L 20,16 L 18,16 L 18,15 C 18,14.442363 18.446,14 19,14 z"
+       id="rect2822"
+       style="opacity:1;fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
 </svg>


### PR DESCRIPTION
Some svg icons have a malformed xml format due to they don't have defined some namespaces like `sodipodi` or `inkscape` in the xml structure. This causes issues like:
https://github.com/ubuntu-mate/ubuntu-mate-artwork/issues/65 OR https://bugs.launchpad.net/ubuntu/+source/ubuntu-mate-artwork/+bug/1875066
This seems to happen because some previous version of Inkscape didn't save files by defining namespaces correctly, so what I did was re-open and re-save those svg files using the last version of `Inkscape 0.92.5 (2060ec1f9f, 2020-04-08)`, that version includes the namespaces correctly.

For scanning the malformed files I made a phyton script, this was the result:
```
Total svg icons parsed: 6232
Total svg icons malformed: 12
usr/share/icons/Radiant-MATE/status/22/nm-device-wired-secure.svg
usr/share/icons/Radiant-MATE/status/22/nm-signal-100-secure.svg
usr/share/icons/Radiant-MATE/status/22/nm-signal-75-secure.svg
usr/share/icons/Radiant-MATE/status/22/nm-signal-00-secure.svg
usr/share/icons/Radiant-MATE/status/22/nm-signal-25-secure.svg
usr/share/icons/Radiant-MATE/status/22/nm-signal-50-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-device-wired-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-signal-100-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-signal-75-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-signal-00-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-signal-25-secure.svg
usr/share/icons/Ambiant-MATE/status/22/nm-signal-50-secure.svg
```
The script code:
```python
import os
import shutil
from pathlib import Path
from lxml import etree
from lxml.etree import LxmlError

ROOT_SEARCH_DIR = Path('/path/to/ubuntu-mate-artwork')
ROOT_BAD_FILES_COPY_DIR = Path('/dir/to/copy/malformed_files')

# Scanning for malformed files
total_svg_parsed = 0
total_svg_malformed = 0
bad_svg_files = []
for root, dirs, files in os.walk(ROOT_SEARCH_DIR):
    for file in files:
        if file.endswith('.svg'):
            total_svg_parsed += 1
            svg_file = Path(root, file)
            try:
                svg_xml = etree.parse(str(svg_file))
            except LxmlError as error:
                total_svg_malformed += 1
                bad_svg_files.append(svg_file)

print('Total svg icons parsed: {}'.format(total_svg_parsed))
print('Total svg icons malformed: {}'.format(total_svg_malformed))

# Copying malformed files to a separate dir
for index, svg_file in enumerate(bad_svg_files):
    local_svg_file = svg_file.relative_to(ROOT_SEARCH_DIR)
    print(local_svg_file)
    new_dir = ROOT_BAD_FILES_COPY_DIR.joinpath(local_svg_file.parent)
    ROOT_BAD_FILES_COPY_DIR.joinpath(local_svg_file.parent).mkdir(parents=True, exist_ok=True)
    shutil.copy2(svg_file, new_dir)
```